### PR TITLE
Update deprecated build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ This CWE SDK has a build process that prepares the JSON data by downloading the 
 
 This work is made possible thanks to scripts in `./build/`
 
+To run it, execute `yarn run build`
+
 # Contributing
 
 Please consult [CONTRIBUTING](./CONTRIBUTING.md) for guidelines on contributing to this project.

--- a/__tests__/CweManager.test.js
+++ b/__tests__/CweManager.test.js
@@ -61,7 +61,7 @@ describe('Cwe Manager', () => {
     test('A CWE ID with memberships should return an array of ids', () => {
       const cweManager = new CweManager()
       const result = cweManager.getMemberships({ weaknessId: '778' })
-      expect(result).toStrictEqual(['1009', '1036', '1210', '1308'])
+      expect(result).toStrictEqual(['1009', '1036', '1210', '1308', '1355', '1413'])
     })
   })
 })

--- a/build/xmlParser.js
+++ b/build/xmlParser.js
@@ -3,7 +3,7 @@
 /* eslint-disable security/detect-object-injection */
 /* eslint-disable security/detect-non-literal-fs-filename */
 const fs = require('fs')
-const parser = require('fast-xml-parser')
+const { XMLParser, XMLValidator } = require('fast-xml-parser')
 const debug = require('debug')('cwe-sdk:build')
 
 function createCweDictionary({ cweArchive }) {
@@ -76,7 +76,7 @@ function convertXmlArchiveToJson({ cweArchiveFilepath }) {
 
   const options = {
     attributeNamePrefix: '@_',
-    attrNodeName: 'attr',
+    attributesGroupName: 'attr',
     textNodeName: '#text',
     ignoreAttributes: false,
     ignoreNameSpace: false,
@@ -88,11 +88,12 @@ function convertXmlArchiveToJson({ cweArchiveFilepath }) {
     arrayMode: false
   }
 
-  if (parser.validate(xmlData) !== true) {
+  if (XMLValidator.validate(xmlData) !== true) {
     // @TODO xmlData is not valid
   }
 
-  const rawJsonCweArchive = parser.parse(xmlData, options)
+  const parser = new XMLParser(options)
+  const rawJsonCweArchive = parser.parse(xmlData)
   return rawJsonCweArchive
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Hi, I am Haebin from [Theori](https://www.theori.io/).
While trying to process CWE data, I came across an OWASP repository that seemed perfect for my needs.
Unfortunately, the code wasn't functioning as expected.
Fortunately, I was able to troubleshoot and resolve the issue, restoring the code's functionality.
I'm here to share my solution. Thank you for your outstanding work!

## Description

<!--- Describe your changes in detail -->
I fixed the build script since it wasn't working anymore due to deprecated usage of the library `fast-xml-parser`.
I also updated README to inform about the build command, and updated the test since it was deprecated too.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#27 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
It makes the build script work.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->
I changed one part of the test, where it contained deprecated information of membership based on the latest version CWE 4.13.

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I added a picture of a cute animal cause it's fun
![image](https://github.com/OWASP/cwe-sdk-javascript/assets/22850304/559532e0-22e2-4c0c-a28b-5b4ea226550a)
